### PR TITLE
Add Visionex '25 to sdgGoals list

### DIFF
--- a/lib/types/mapping.ts
+++ b/lib/types/mapping.ts
@@ -273,5 +273,6 @@ export const sdgGoals = [
       { value: "I-24-sep", label: "Infoschol '24 Sep" ,type: "Infoschol" },
       { value: "I-25-jan", label: "Infoschol '25 Jan" ,type: "Infoschol" },
       { value: "I-25-sep", label: "Infoschol '25 Sep" ,type: "Infoschol" },
+      { value: "V-25", label: "Visionex '25" ,type: "Visonex" },
       
     ]

--- a/lib/types/mapping.ts
+++ b/lib/types/mapping.ts
@@ -273,6 +273,5 @@ export const sdgGoals = [
       { value: "I-24-sep", label: "Infoschol '24 Sep" ,type: "Infoschol" },
       { value: "I-25-jan", label: "Infoschol '25 Jan" ,type: "Infoschol" },
       { value: "I-25-sep", label: "Infoschol '25 Sep" ,type: "Infoschol" },
-      { value: "V-25", label: "Visionex '25" ,type: "Visonex" },
-      
+      { value: "V-25", label: "Visionex '25" ,type: "Visionex" },
     ]


### PR DESCRIPTION
Introduced a new entry for Visionex '25 in the sdgGoals array to support the upcoming event. This allows the system to recognize and handle Visionex '25 as a valid option.